### PR TITLE
Allow PHPStan to be installed in version 2.0 and greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-        "phpstan/phpstan": "^1.9.0"
+        "phpstan/phpstan": "^1.9.0|^2.0"
     },
     "prefer-stable": true,
     "extra": {


### PR DESCRIPTION
Since stub definitions should be compatible between 1.x and 2.x version I think it would be beneficial to also have possibility to use it with new version without any limitation.